### PR TITLE
feat: strip markdown from quotes

### DIFF
--- a/cogs/quote_generator_cog/main.py
+++ b/cogs/quote_generator_cog/main.py
@@ -1,3 +1,4 @@
+from cogs.quote_generator_cog.markdown import remove_markdown_from_message
 from cogs.quote_generator_cog.quote_generator_helper.image_creator import dir_path, create_image
 from cogs.quote_generator_cog.quote_generator_helper.image_creator2 import dir_path as dir_path2, create_image2
 from base_cog import BaseCog
@@ -89,6 +90,7 @@ async def get_html_css_info(channel, message_id, server, message=None):
         message = await channel.fetch_message(message_id)
     user = message.author
     message_content = remove_emoji_from_message(message.content)
+    message_content = remove_markdown_from_message(message_content)
 
     # Replace mentions (<@id>, <@!id>), role mentions (<@&id>) and channel mentions (<#id>)
     # with human readable forms so the generated image shows names instead of raw IDs.

--- a/cogs/quote_generator_cog/markdown.py
+++ b/cogs/quote_generator_cog/markdown.py
@@ -32,7 +32,7 @@ def remove_markdown_from_message(message: str) -> str:
         is_in_code_block = expecting_closing["`"] or expecting_closing["```"]
 
         # Handle escaped characters first
-        if character == "\\" and not message[index + 1].isalnum() and not is_in_code_block:
+        if character == "\\" and index + 1 < len(message) and not message[index + 1].isalnum() and not is_in_code_block:
             output.write(message[index + 1])
             index += 2
             is_new_line = False
@@ -69,7 +69,7 @@ def remove_markdown_from_message(message: str) -> str:
                 index += length
 
                 if template == "```" and not want_to_close:
-                    end = message.index(template, index + length)
+                    end = message.index(template, index)
                     
                     if "\n" in message[index + length:end]:
                         while message[index].isalnum():
@@ -93,13 +93,13 @@ def remove_markdown_from_message(message: str) -> str:
                 new_index += 1
 
             bounds_check = new_index >= len(message)
-            if bounds_check or message[new_index + 1] != "(":
+            if bounds_check or new_index + 1 >= len(message) or message[new_index + 1] != "(":
                 output.write("[" + remove_markdown_from_message(label.getvalue()))
 
                 if not bounds_check:
                     output.write("]")
 
-                index = new_index + 2
+                index = new_index + 1
                 is_new_line = False
                 continue
 

--- a/cogs/quote_generator_cog/markdown.py
+++ b/cogs/quote_generator_cog/markdown.py
@@ -40,6 +40,8 @@ def remove_markdown_from_message(message: str) -> str:
 
         # Strip headers, subtext, and quotes
         if is_new_line and not is_in_code_block:
+            next_four = message[index:index+4]
+
             if next_two == "> " or next_two == "# ":
                 index += 2
                 is_new_line = False
@@ -50,7 +52,7 @@ def remove_markdown_from_message(message: str) -> str:
                 is_new_line = False
                 continue
 
-            if message[index:index+4] == "### ":
+            if next_four == "### " or next_four == ">>> ":
                 index += 4
                 is_new_line = False
                 continue

--- a/cogs/quote_generator_cog/markdown.py
+++ b/cogs/quote_generator_cog/markdown.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from urllib.parse import urlparse
 
-def remove_markdown_from_message(message: str) -> str:
+def remove_markdown_from_message(message: str, current_recursion_size: int = 0) -> str:
     """
     Parses text and removes all markdown from it.
     Covers only Discord's subset of markdown.
@@ -13,6 +13,12 @@ def remove_markdown_from_message(message: str) -> str:
     # We need to handle spoilers (||hello||)
     # We need to handle quotes (> hello)
     # We need to handle escaped characters
+
+    # If we've recursed 100 calls deep, it's probably a malicious message.
+    # We'll just return the message as-is, which will likely cause the
+    # "I'm limited to 250 characters" message, preventing the quote.
+    if current_recursion_size > 100:
+        return message
 
     templates = ("||", "**", "*", "__", "_", "~~", "```", "`")
     supported_protocols = ("http", "https")
@@ -96,7 +102,7 @@ def remove_markdown_from_message(message: str) -> str:
 
             bounds_check = new_index >= len(message)
             if bounds_check or new_index + 1 >= len(message) or message[new_index + 1] != "(":
-                output.write("[" + remove_markdown_from_message(label.getvalue()))
+                output.write("[" + remove_markdown_from_message(label.getvalue(), current_recursion_size + 1))
 
                 if not bounds_check:
                     output.write("]")
@@ -109,15 +115,26 @@ def remove_markdown_from_message(message: str) -> str:
             # that `message[new_index + 1]` is `(`, so we can skip 2 chars
             new_index += 2
             url = StringIO()
+            is_nesting = False
 
-            while new_index < len(message) and message[new_index] != ")":
+            while new_index < len(message) and (message[new_index] != ")" or is_nesting):
+                # Technically, Discord's hyperlink parsing is actually not spec-compliant.
+                # It can match parentheses in URLs, but it does not allow any nesting.
+                # This implementation matches that behavior for accuracy with Discord.
+                if message[new_index] == "(":
+                    is_nesting = True
+                elif message[new_index] == ")":
+                    is_nesting = False
+
                 url.write(message[new_index])
                 new_index += 1
 
             bounds_check = new_index >= len(message)
             full_url = url.getvalue()
             if bounds_check or urlparse(full_url).scheme not in supported_protocols:
-                output.write("[" + remove_markdown_from_message(label.getvalue()) + "](" + remove_markdown_from_message(full_url))
+                escaped_label = remove_markdown_from_message(label.getvalue(), current_recursion_size + 1)
+                escaped_url = remove_markdown_from_message(full_url, current_recursion_size + 1)
+                output.write("[" + escaped_label + "](" + escaped_url)
 
                 if not bounds_check:
                     output.write(")")
@@ -126,7 +143,7 @@ def remove_markdown_from_message(message: str) -> str:
                 is_new_line = False
                 continue
 
-            output.write(remove_markdown_from_message(label.getvalue()))
+            output.write(remove_markdown_from_message(label.getvalue(), current_recursion_size + 1))
             index = new_index + 1
             is_new_line = False
             continue

--- a/cogs/quote_generator_cog/markdown.py
+++ b/cogs/quote_generator_cog/markdown.py
@@ -1,0 +1,137 @@
+from io import StringIO
+from urllib.parse import urlparse
+
+def remove_markdown_from_message(message: str) -> str:
+    """
+    Parses text and removes all markdown from it.
+    Covers only Discord's subset of markdown.
+    """
+
+    # We need to handle bold/italics/underline/strikethrough (**, */_, __, ~~)
+    # We need to handle hyperlinks ([hello](https://google.com/))
+    # We need to handle code blocks (`hello`, ```hello```)
+    # We need to handle spoilers (||hello||)
+    # We need to handle quotes (> hello)
+    # We need to handle escaped characters
+
+    templates = ("||", "**", "*", "__", "_", "~~", "```", "`")
+    supported_protocols = ("http", "https")
+
+    index = 0
+    output = StringIO()
+    is_new_line = True
+    expecting_closing = {}
+
+    for template in templates:
+        expecting_closing[template] = False
+
+    while index < len(message):
+        character = message[index]
+        next_two = message[index:index+2]
+        next_three = message[index:index+3]
+        is_in_code_block = expecting_closing["`"] or expecting_closing["```"]
+
+        # Handle escaped characters first
+        if character == "\\" and not message[index + 1].isalnum() and not is_in_code_block:
+            output.write(message[index + 1])
+            index += 2
+            is_new_line = False
+            continue
+
+        # Strip headers, subtext, and quotes
+        if is_new_line and not is_in_code_block:
+            if next_two == "> " or next_two == "# ":
+                index += 2
+                is_new_line = False
+                continue
+
+            if next_three == "## " or next_three == "-# ":
+                index += 3
+                is_new_line = False
+                continue
+
+            if message[index:index+4] == "### ":
+                index += 4
+                is_new_line = False
+                continue
+
+        should_continue_after_templates = False
+
+        # Strip spoilers, bold, italics, underline, strikethrough, and code blocks
+        for template in templates:
+            if (expecting_closing["`"] and template != "`") or (expecting_closing["```"] and template != "```"):
+                continue
+
+            length = len(template)
+            want_to_close = expecting_closing[template]
+
+            if message[index:index+length] == template and (want_to_close or template in message[index+length:]):
+                index += length
+
+                if template == "```" and not want_to_close:
+                    end = message.index(template, index + length)
+                    
+                    if "\n" in message[index + length:end]:
+                        while message[index].isalnum():
+                            index += 1
+
+                expecting_closing[template] = not want_to_close
+                should_continue_after_templates = True
+                is_new_line = False
+                break
+
+        if should_continue_after_templates:
+            continue
+
+        # Strip hyperlinks
+        if character == "[" and not is_in_code_block:
+            new_index = index + 1
+            label = StringIO()
+
+            while new_index < len(message) and message[new_index] != "]":
+                label.write(message[new_index])
+                new_index += 1
+
+            bounds_check = new_index >= len(message)
+            if bounds_check or message[new_index + 1] != "(":
+                output.write("[" + remove_markdown_from_message(label.getvalue()))
+
+                if not bounds_check:
+                    output.write("]")
+
+                index = new_index + 2
+                is_new_line = False
+                continue
+
+            # By this point, we know that `message[new_index]` is `]` and
+            # that `message[new_index + 1]` is `(`, so we can skip 2 chars
+            new_index += 2
+            url = StringIO()
+
+            while new_index < len(message) and message[new_index] != ")":
+                url.write(message[new_index])
+                new_index += 1
+
+            bounds_check = new_index >= len(message)
+            full_url = url.getvalue()
+            if bounds_check or urlparse(full_url).scheme not in supported_protocols:
+                output.write("[" + remove_markdown_from_message(label.getvalue()) + "](" + remove_markdown_from_message(full_url))
+
+                if not bounds_check:
+                    output.write(")")
+
+                index = new_index + 1
+                is_new_line = False
+                continue
+
+            output.write(remove_markdown_from_message(label.getvalue()))
+            index = new_index + 1
+            is_new_line = False
+            continue
+
+        # These should be normal characters which we can consume w/o concern
+        is_new_line = character == "\n"
+        output.write(character)
+        index += 1
+
+    return output.getvalue()

--- a/cogs/quote_generator_cog/markdown.py
+++ b/cogs/quote_generator_cog/markdown.py
@@ -126,6 +126,12 @@ def remove_markdown_from_message(message: str, current_recursion_size: int = 0) 
                 elif message[new_index] == ")":
                     is_nesting = False
 
+                # Discord doesn't support escaped characters in nested parentheses, ironically.
+                if not is_nesting and message[new_index] == "\\" and new_index + 1 < len(message) and not message[new_index + 1].isalnum():
+                    url.write(message[new_index + 1])
+                    new_index += 2
+                    continue
+
                 url.write(message[new_index])
                 new_index += 1
 

--- a/cogs/quote_generator_cog/markdown.py
+++ b/cogs/quote_generator_cog/markdown.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from urllib.parse import urlparse
 
-def remove_markdown_from_message(message: str, current_recursion_size: int = 0) -> str:
+def remove_markdown_from_message(message: str, current_recursion_size: int = 0, allow_escapes: bool = True) -> str:
     """
     Parses text and removes all markdown from it.
     Covers only Discord's subset of markdown.
@@ -39,7 +39,15 @@ def remove_markdown_from_message(message: str, current_recursion_size: int = 0) 
 
         # Handle escaped characters first
         if character == "\\" and index + 1 < len(message) and not message[index + 1].isalnum() and not is_in_code_block:
-            output.write(message[index + 1])
+            if allow_escapes:
+                output.write(message[index + 1])
+            else:
+                # Manually write the backslash and its following character.
+                # This mimics a bug in Discord's markdown parser, where escaped
+                # characters are not handled properly in hyperlink labels.
+                output.write("\\")
+                output.write(message[index + 1])
+
             index += 2
             is_new_line = False
             continue
@@ -127,7 +135,7 @@ def remove_markdown_from_message(message: str, current_recursion_size: int = 0) 
                     is_nesting = False
 
                 # Discord doesn't support escaped characters in nested parentheses, ironically.
-                if not is_nesting and message[new_index] == "\\" and new_index + 1 < len(message) and not message[new_index + 1].isalnum():
+                if allow_escapes and not is_nesting and message[new_index] == "\\" and new_index + 1 < len(message) and not message[new_index + 1].isalnum():
                     url.write(message[new_index + 1])
                     new_index += 2
                     continue
@@ -149,7 +157,7 @@ def remove_markdown_from_message(message: str, current_recursion_size: int = 0) 
                 is_new_line = False
                 continue
 
-            output.write(remove_markdown_from_message(label.getvalue(), current_recursion_size + 1))
+            output.write(remove_markdown_from_message(label.getvalue(), current_recursion_size + 1, False))
             index = new_index + 1
             is_new_line = False
             continue

--- a/cogs/quote_generator_cog/markdown.py
+++ b/cogs/quote_generator_cog/markdown.py
@@ -79,7 +79,7 @@ def remove_markdown_from_message(message: str, current_recursion_size: int = 0) 
                 if template == "```" and not want_to_close:
                     end = message.index(template, index)
                     
-                    if "\n" in message[index + length:end]:
+                    if "\n" in message[index:end]:
                         while message[index].isalnum():
                             index += 1
 


### PR DESCRIPTION
Strips markdown formatting from messages when generating quotes. This handles all markdown formatting supported by Discord that I am aware of. This includes bold, italics, strikethrough, underline, subtext, headers, spoilers, quote blocks, code blocks, hyperlinks, and escaping characters.

I thought about if spoilers should be stripped or hidden (given the point of spoilers), but my justification was that it's unlikely for somebody to quote something with actual, harmful content (eg. movie spoilers or sensitive topics), and quotes are generally used for comedic value instead, so I don't think it'll be an issue.

if there are issues with code quality (be it style, or other concerns), i'm happy to make changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quoted and referenced messages in generated images now have Markdown stripped for cleaner, more readable text. Handles spoilers, emphasis/strikethrough/underline, code spans/blocks, header/quote prefixes, and links (shows link labels for standard http/https). Preserves intended escaped characters and includes safeguards to avoid excessive or pathological nesting during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->