### PR TITLE
Update aliases for nowplaying command

### DIFF
--- a/cogs/spotify_cog/main.py
+++ b/cogs/spotify_cog/main.py
@@ -163,7 +163,7 @@ class SpotifyCog(BaseCog):
             logger.exception("Failed to send Spotify view for %s", target)
             await ctx.send(embed=red_embed("Something went wrong sending the embed."))
 
-    @commands.hybrid_command(name="nowplaying", aliases=['spoti', 'np'])
+    @commands.hybrid_command(name="nowplaying", aliases=['nowplay', 'np', 'spotify'])
     @commands.cooldown(1, 10, commands.BucketType.user)
     @app_commands.describe(member="The user to check (leave empty for yourself)")
     async def nowplaying(self, ctx: commands.Context, member: Optional[Member] = None):  # noqa: UP045 — discord.py needs Optional[]


### PR DESCRIPTION
Makes more sense 'nowplay' or 'spotify'

_what tha actual fuck is spoti_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new command aliases for the Spotify now playing feature, providing users with additional shortcuts to quickly access current playback information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->